### PR TITLE
Downdate syntax to work with Ruby 1.9

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,12 +1,23 @@
 machine:
   ruby:
-    version: 2.2.2
+    version: 2.2.3
 dependencies:
-  pre:
-    - gem install bundler --pre
+  cache_directories:
+    - 'vendor/bundle'
+  override:
+    - rvm-exec 2.2.3 bash -c "bundle check --path=vendor/bundle || bundle install --path=vendor/bundle"
+    - rvm-exec 2.1.6 bash -c "bundle check --path=vendor/bundle || bundle install --path=vendor/bundle"
+    - rvm-exec 2.0.0-p645 bash -c "bundle check --path=vendor/bundle || bundle install --path=vendor/bundle"
+    - rvm-exec 1.9.3-p551 bash -c "bundle check --path=vendor/bundle || bundle install --path=vendor/bundle"
 test:
   override:
-    - bundle exec rspec --order rand -fd --format RspecJunitFormatter --out $CIRCLE_TEST_REPORTS/rspec.xml:
+    - rvm-exec 2.2.3 bash -c "bundle exec rspec --order rand -fd --format RspecJunitFormatter --out $CIRCLE_TEST_REPORTS/rspec-2_2_3.xml":
+        parallel: true
+    - rvm-exec 2.1.6 bash -c "bundle exec rspec --order rand -fd --format RspecJunitFormatter --out $CIRCLE_TEST_REPORTS/rspec-2_1_6.xml":
+        parallel: true
+    - rvm-exec 2.0.0-p645 bash -c "bundle exec rspec --order rand -fd --format RspecJunitFormatter --out $CIRCLE_TEST_REPORTS/rspec-2_0_0.xml":
+        parallel: true
+    - rvm-exec 1.9.3-p551 bash -c "bundle exec rspec --order rand -fd --format RspecJunitFormatter --out $CIRCLE_TEST_REPORTS/rspec-1_9_3.xml":
         parallel: true
   post:
     - bundle exec rubocop

--- a/lib/tablexi/logger.rb
+++ b/lib/tablexi/logger.rb
@@ -24,13 +24,15 @@ module Tablexi
           logger.handlers[severity] << Tablexi::Logger::Standard.new(base_logger, severity: severity)
         end
 
-        trackable_severities = %i(error fatal unknown)
+        trackable_severities = [:error, :fatal, :unknown]
         logger.handle trackable_severities, &Tablexi::Logger::Rollbar if defined?(::Rollbar)
         logger.handle trackable_severities, &Tablexi::Logger::NewRelic if defined?(::NewRelic)
       end
     end
 
-    private def bare_logger
+    private
+
+    def bare_logger
       return @bare_logger if @bare_logger
       @bare_logger = ::Logger.new($stdout).tap do |config|
         config.level = ::Logger::DEBUG
@@ -57,7 +59,7 @@ module Tablexi
 
     SEVERITIES.each do |severity|
       define_method(severity) do |exception_or_message, options = {}|
-        log(severity, exception_or_message, Hash(options))
+        log(severity, exception_or_message, Hash[options])
       end
     end
 

--- a/lib/tablexi/logger/severities.rb
+++ b/lib/tablexi/logger/severities.rb
@@ -1,14 +1,14 @@
 module Tablexi
   class Logger
     module Severities
-      SEVERITIES = %i(
-        debug
-        info
-        warn
-        error
-        fatal
-        unknown
-      ).freeze
+      SEVERITIES = [
+        :debug,
+        :info,
+        :warn,
+        :error,
+        :fatal,
+        :unknown,
+      ].freeze
     end
   end
 end

--- a/lib/tablexi/logger/standard.rb
+++ b/lib/tablexi/logger/standard.rb
@@ -8,7 +8,9 @@ module Tablexi
       attr_reader :logger
       attr_reader :severity
 
-      def initialize(logger, options = { severity: :unknown })
+      def initialize(logger, options = {})
+        defaults = { severity: :unknown }
+        options = defaults.merge(options)
         severity = options[:severity]
         raise ArgumentError, "Severity `#{severity}` must be one of #{SEVERITIES}" unless SEVERITIES.include?(severity)
 

--- a/lib/tablexi/logger/standard.rb
+++ b/lib/tablexi/logger/standard.rb
@@ -8,7 +8,8 @@ module Tablexi
       attr_reader :logger
       attr_reader :severity
 
-      def initialize(logger, severity: :unknown)
+      def initialize(logger, options = { severity: :unknown })
+        severity = options[:severity]
         raise ArgumentError, "Severity `#{severity}` must be one of #{SEVERITIES}" unless SEVERITIES.include?(severity)
 
         @logger = logger
@@ -22,7 +23,7 @@ module Tablexi
       private
 
       def generate_log(exception_or_message, options)
-        options = Hash(options)
+        options = Hash[options]
 
         message = []
         message << (exception_or_message.respond_to?(:message) ? exception_or_message.message : exception_or_message)

--- a/tablexi-logger.gemspec
+++ b/tablexi-logger.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.10"
+  spec.add_development_dependency "bundler", "~> 1.9"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.2"
   spec.add_development_dependency "rspec_junit_formatter"


### PR DESCRIPTION
This is all green for me under Rubies 1.9.3, 2.0.0, 2.1.7 and 2.2.3.

Converting from `%i()` wasn't too bad but I had to take a shower after turning the keyword arguments into an options hash.

I wouldn't mind keeping this as a separate branch for the few projects that need it, with the understanding that its days are numbered.